### PR TITLE
Align item actions with active tab

### DIFF
--- a/app/(app)/incidents/view.tsx
+++ b/app/(app)/incidents/view.tsx
@@ -106,12 +106,13 @@ export default function ViewIncident() {
   const [newNoteHeight, setNewNoteHeight] = useState<number | undefined>(undefined);
   const [notifyCitizen, setNotifyCitizen] = useState(true);
 
-  // SECTION for UI permissions: derive from *current status* (so actions update as status changes)
+  // SECTION for UI permissions: base on current status but respect incoming tab before load
   const section: Section = useMemo<Section>(() => {
+    if (!report && backTab) return backTab;
     if (status === "Resolved") return "solved";
     if (status === "New" || status === "In Review") return "pending";
     return "ongoing"; // Approved, Assigned, Ongoing
-  }, [status]);
+  }, [backTab, report, status]);
 
   // Officer permissions per section
   const canApproveReject = role === "officer" && section === "pending" && (status === "New" || status === "In Review");

--- a/app/(app)/lost-found/officer-lost.tsx
+++ b/app/(app)/lost-found/officer-lost.tsx
@@ -306,7 +306,10 @@ export default function OfficerLost() {
                     >
                       <Pressable
                         onPress={() =>
-                          router.push({ pathname: "/lost-found/view", params: { id: r.id, type: "lost", role: "officer" } })
+                          router.push({
+                            pathname: "/lost-found/view",
+                            params: { id: r.id, type: "lost", role: "officer", tab: activeTab },
+                          })
                         }
                       >
                         {/* Header: responsive to avoid overlap */}


### PR DESCRIPTION
## Summary
- pass current tab when navigating to lost-item details so actions match tab
- base lost-item and incident detail actions on tab or status, and navigate back to the right tab
- restrict lost-item editing to citizens

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bdb0ef2ab0832a8a119ae39c10e909