### PR TITLE
refactor: remove React default imports

### DIFF
--- a/app/(app)/_layout.tsx
+++ b/app/(app)/_layout.tsx
@@ -1,6 +1,6 @@
 // app/(app)/_layout.tsx
 import { Stack, Redirect } from "expo-router";
-import React, { useContext, useEffect } from "react";
+import { useContext, useEffect } from "react";
 import { AuthContext } from "@/context/AuthContext";
 
 /**

--- a/app/(app)/alerts/_layout.tsx
+++ b/app/(app)/alerts/_layout.tsx
@@ -1,6 +1,5 @@
 // app/(app)/alerts/_layout.tsx
 import { Stack } from "expo-router";
-import React from "react";
 
 /**
  * Alerts group layout.

--- a/app/(app)/alerts/citizen.tsx
+++ b/app/(app)/alerts/citizen.tsx
@@ -1,7 +1,7 @@
 // app/(app)/alerts/citizen.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Animated, Keyboard, Pressable, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 

--- a/app/(app)/alerts/edit.tsx
+++ b/app/(app)/alerts/edit.tsx
@@ -1,7 +1,7 @@
 // app/(app)/alerts/edit.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Animated, Keyboard, Pressable, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 

--- a/app/(app)/alerts/manage.tsx
+++ b/app/(app)/alerts/manage.tsx
@@ -1,7 +1,7 @@
 // app/(app)/alerts/manage.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
     ActivityIndicator,
     Animated,

--- a/app/(app)/home.tsx
+++ b/app/(app)/home.tsx
@@ -1,6 +1,15 @@
 // app/home.tsx
 import { router, useLocalSearchParams } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type FC,
+  type ReactNode,
+} from 'react';
 import {
   ActivityIndicator,
   Animated,
@@ -43,7 +52,7 @@ import {
 } from 'lucide-react-native';
 
 type Role = 'citizen' | 'officer';
-type IconType = React.ComponentType<{ size?: number; color?: string }>;
+type IconType = ComponentType<{ size?: number; color?: string }>;
 type Tone = 'primary' | 'ring' | 'accent' | 'destructive' | 'foreground';
 
 /** Tailwind tone → class maps (BG/Text variants and faint BG) */
@@ -577,14 +586,14 @@ function getGreeting(hour: number): 'Good morning' | 'Good afternoon' | 'Good ev
 /* -------------------- UI Partials -------------------- */
 
 /** Card container with standard padding, border, and rounded corners. */
-const Card: React.FC<{ children: React.ReactNode }> = ({ children }) => (
+const Card: FC<{ children: ReactNode }> = ({ children }) => (
   <View className="rounded-2xl border border-border bg-muted p-5">{children}</View>
 );
 
 /**
  * Section header with title, optional action, and tone bar.
  */
-const CardHeader: React.FC<{
+const CardHeader: FC<{
   title: string;
   actionLabel?: string;
   onAction?: () => void;
@@ -608,7 +617,7 @@ const CardHeader: React.FC<{
 );
 
 /** Compact trend chip (up/down + %). */
-const TrendChip: React.FC<{ dir: 'up' | 'down'; pct: number; tone: Tone }> = ({
+const TrendChip: FC<{ dir: 'up' | 'down'; pct: number; tone: Tone }> = ({
   dir,
   pct,
   tone,
@@ -627,7 +636,7 @@ const TrendChip: React.FC<{ dir: 'up' | 'down'; pct: number; tone: Tone }> = ({
 );
 
 /** KPI block with optional trend and progress bar. */
-const Kpi: React.FC<{
+const Kpi: FC<{
   label: string;
   value: number | string;
   tone?: Tone;
@@ -663,7 +672,7 @@ type Tile = {
 };
 
 /** Responsive 2-column grid of action tiles. */
-const TileGrid: React.FC<{ tiles: Tile[] }> = ({ tiles }) => (
+const TileGrid: FC<{ tiles: Tile[] }> = ({ tiles }) => (
   <View className="-mx-1 mt-3 flex-row flex-wrap">
     {tiles.map((t, i) => (
       <View key={i} className="mb-2 basis-1/2 px-1">
@@ -674,7 +683,7 @@ const TileGrid: React.FC<{ tiles: Tile[] }> = ({ tiles }) => (
 );
 
 /** Action tile button with optional count badge. */
-const IconTileButton: React.FC<Tile> = ({
+const IconTileButton: FC<Tile> = ({
   label,
   icon: IconCmp,
   onPress,
@@ -719,7 +728,7 @@ type ListItem = {
 };
 
 /** Empty state block used by list/timeline components. */
-const EmptyState: React.FC<{
+const EmptyState: FC<{
   title: string;
   subtitle?: string;
   icon?: IconType;
@@ -737,7 +746,7 @@ const EmptyState: React.FC<{
 );
 
 /** Generic list with icon, title, and meta; shows empty state when needed, supports onPress per row. */
-const List: React.FC<{
+const List: FC<{
   items: ListItem[];
   className?: string;
   emptyTitle?: string;
@@ -797,7 +806,7 @@ const List: React.FC<{
 };
 
 /** Vertical timeline with bullets and a guiding line; includes empty state. */
-const Timeline: React.FC<{
+const Timeline: FC<{
   items: ListItem[];
   className?: string;
   emptyTitle?: string;
@@ -844,7 +853,7 @@ const Timeline: React.FC<{
 };
 
 /** Floating chatbot widget (citizen only). */
-const ChatbotWidget: React.FC<{
+const ChatbotWidget: FC<{
   open: boolean;
   onToggle: () => void;
   message: string;

--- a/app/(app)/incidents/_layout.tsx
+++ b/app/(app)/incidents/_layout.tsx
@@ -1,6 +1,5 @@
 // app/(app)/incidents/_layout.tsx
 import { Stack } from "expo-router";
-import React from "react";
 
 /**
  * Incidents group layout.

--- a/app/(app)/incidents/manage-incidents.tsx
+++ b/app/(app)/incidents/manage-incidents.tsx
@@ -1,7 +1,7 @@
 // app/(app)/incidents/manage-incidents.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ComponentType } from "react";
 import {
   Animated,
   Keyboard,
@@ -235,7 +235,7 @@ export default function ManageIncidents() {
     tab: TabKey;
     label: string;
     count?: number;
-    Icon: React.ComponentType<{ size?: number; color?: string }>;
+    Icon: ComponentType<{ size?: number; color?: string }>;
   }) => {
     const active = activeTab === tab;
     const h = isCompact ? 36 : 40;

--- a/app/(app)/incidents/my-reports.tsx
+++ b/app/(app)/incidents/my-reports.tsx
@@ -1,6 +1,6 @@
 // app/(app)/incidents/my-reports.tsx
 import { router } from "expo-router";
-import React, { useMemo, useState } from "react";
+import { useMemo, useState, type ComponentType, type FC, type ReactNode } from "react";
 import { Pressable, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
@@ -17,7 +17,7 @@ import {
 /** Types */
 type Priority = "Urgent" | "Normal" | "Low";
 type Status = "New" | "In Review" | "Approved" | "Assigned" | "Ongoing" | "Resolved";
-type IconType = React.ComponentType<{ size?: number; color?: string }>;
+type IconType = ComponentType<{ size?: number; color?: string }>;
 
 type Row = {
   id: string;
@@ -28,13 +28,13 @@ type Row = {
 };
 
 /** Helpers */
-const Card: React.FC<{ children: React.ReactNode; className?: string }> = ({ children, className }) => (
+const Card: FC<{ children: ReactNode; className?: string }> = ({ children, className }) => (
   <View className={`bg-muted rounded-2xl border border-border ${className ?? ""}`}>
     <View className="p-4">{children}</View>
   </View>
 );
 
-const CardHeader: React.FC<{ title: string; tone?: "primary" | "ring" | "accent" | "destructive" | "foreground" }> = ({
+const CardHeader: FC<{ title: string; tone?: "primary" | "ring" | "accent" | "destructive" | "foreground" }> = ({
   title,
   tone = "foreground",
 }) => {

--- a/app/(app)/incidents/report-incidents.tsx
+++ b/app/(app)/incidents/report-incidents.tsx
@@ -1,7 +1,16 @@
 // app/(app)/incidents/report-incidents.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+  type ComponentType,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from "react";
 import type { NativeSyntheticEvent, TextInput as RNTextInput, TextInputContentSizeChangeEventData } from "react-native";
 import {
   Animated,
@@ -170,7 +179,7 @@ export default function ReportIncidents() {
     Icon,
   }: {
     value: typeof category;
-    Icon: React.ComponentType<{ size?: number; color?: string }>;
+    Icon: ComponentType<{ size?: number; color?: string }>;
   }) => {
     const active = category === value;
     return (
@@ -321,8 +330,8 @@ function WitnessSection({
   formatPhoneDisplay,
 }: {
   witnesses: Witness[];
-  setWitnesses: React.Dispatch<React.SetStateAction<Witness[]>>;
-  nameRefs: React.MutableRefObject<Record<string, RNTextInput | null>>;
+  setWitnesses: Dispatch<SetStateAction<Witness[]>>;
+  nameRefs: MutableRefObject<Record<string, RNTextInput | null>>;
   isValidPhone: (v: string) => boolean;
   formatPhoneDisplay: (v: string) => string;
 }) {

--- a/app/(app)/incidents/view.tsx
+++ b/app/(app)/incidents/view.tsx
@@ -1,7 +1,13 @@
 // app/(app)/incidents/view.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  createElement,
+} from "react";
 import { ActivityIndicator, Animated, Keyboard, Pressable, Switch, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
@@ -271,7 +277,7 @@ export default function ViewIncident() {
             {/* Meta row */}
             <View className="flex-row flex-wrap items-center gap-2">
               <View className="flex-row items-center gap-1 bg-background border border-border rounded-lg px-2 py-1">
-                {catIcon ? React.createElement(catIcon, { size: 14, color: "#0F172A" }) : <Info size={14} color="#0F172A" />}
+                {catIcon ? createElement(catIcon, { size: 14, color: "#0F172A" }) : <Info size={14} color="#0F172A" />}
                 <Text className="text-[12px] text-foreground">{report.category}</Text>
               </View>
               <View className="flex-row items-center gap-1 bg-background border border-border rounded-lg px-2 py-1">

--- a/app/(app)/lost-found/_layout.tsx
+++ b/app/(app)/lost-found/_layout.tsx
@@ -1,6 +1,5 @@
 // app/(app)/lost-found/_layout.tsx
 import { Stack } from "expo-router";
-import React from "react";
 
 /**
  * Lost & Found group layout.

--- a/app/(app)/lost-found/citizen.tsx
+++ b/app/(app)/lost-found/citizen.tsx
@@ -1,5 +1,5 @@
 import { router } from "expo-router";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import {
   ActivityIndicator,
   Animated,

--- a/app/(app)/lost-found/officer-found.tsx
+++ b/app/(app)/lost-found/officer-found.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import { router } from "expo-router";
-import React, { useState } from "react";
+import { useState } from "react";
 import { Animated, Pressable, ScrollView, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 

--- a/app/(app)/lost-found/officer-lost.tsx
+++ b/app/(app)/lost-found/officer-lost.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type ComponentType } from "react";
 import {
     Animated,
     Keyboard,
@@ -209,7 +209,7 @@ export default function OfficerLost() {
     tab: TabKey;
     label: string;
     count?: number;
-    Icon: React.ComponentType<{ size?: number; color?: string }>;
+    Icon: ComponentType<{ size?: number; color?: string }>;
   }) => {
     const active = activeTab === tab;
     const h = isCompact ? 36 : 40;

--- a/app/(app)/lost-found/view.tsx
+++ b/app/(app)/lost-found/view.tsx
@@ -1,7 +1,7 @@
 // app/(app)/lost-found/view.tsx
 import { useNavigation } from "@react-navigation/native";
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { ActivityIndicator, Animated, Pressable, ScrollView, View } from "react-native";
 
 import { toast } from "@/components/toast";

--- a/app/(auth)/_layout.tsx
+++ b/app/(auth)/_layout.tsx
@@ -1,6 +1,5 @@
 // app/(auth)/_layout.tsx
 import { Stack } from "expo-router";
-import React from "react";
 
 /**
  * Auth group layout.

--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -1,6 +1,12 @@
 // app/(auth)/login.tsx
 import { router } from "expo-router";
-import React, { useEffect, useRef, useState } from "react";
+import {
+  useEffect,
+  useRef,
+  useState,
+  useContext,
+  type ComponentType,
+} from "react";
 import {
   ActivityIndicator,
   Animated,
@@ -27,7 +33,6 @@ import {
   Shield,
   UserRound,
 } from "lucide-react-native";
-import { useContext } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import { apiService } from "@/services/apiService";
 
@@ -319,7 +324,7 @@ function SegTab({
 }: {
   active: boolean;
   label: string;
-  icon: React.ComponentType<{ size?: number; color?: string }>;
+    icon: ComponentType<{ size?: number; color?: string }>;
   onPress: () => void;
 }) {
   return (

--- a/app/(auth)/mfa.tsx
+++ b/app/(auth)/mfa.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/mfa.tsx
 import { router, useLocalSearchParams } from "expo-router";
-import React, { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   ActivityIndicator,
   Animated,

--- a/app/(auth)/register.tsx
+++ b/app/(auth)/register.tsx
@@ -1,6 +1,6 @@
 // app/(auth)/register.tsx
 import { router } from "expo-router";
-import React, { useRef, useState } from "react";
+import { useRef, useState, useContext } from "react";
 import { ActivityIndicator, Animated, Image, Keyboard, View } from "react-native";
 import { KeyboardAwareScrollView } from "react-native-keyboard-aware-scroll-view";
 
@@ -11,7 +11,6 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Text } from "@/components/ui/text";
 import { Lock, Mail, UserRound } from "lucide-react-native";
-import { useContext } from "react";
 import { AuthContext } from "@/context/AuthContext";
 import { apiService } from "@/services/apiService";
 import useMountAnimation from "@/hooks/useMountAnimation";

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,7 +3,6 @@ import { ToastOverlay } from "@/components/toast";
 import { AuthProvider } from "@/context/AuthContext";
 import { PortalHost } from "@rn-primitives/portal";
 import { Slot } from "expo-router";
-import React from "react";
 import { SafeAreaView, StatusBar } from "react-native";
 import "../global.css";
 

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,6 +1,6 @@
 // app/index.tsx
 import { router } from "expo-router";
-import React, { useEffect, useContext } from "react";
+import { useEffect, useContext } from "react";
 import { ActivityIndicator, InteractionManager, View } from "react-native";
 import { AuthContext } from "@/context/AuthContext";
 

--- a/components/toast.tsx
+++ b/components/toast.tsx
@@ -1,5 +1,5 @@
 import { Text } from "@/components/ui/text";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import { View } from "react-native";
 
 type Variant = "success" | "error" | "info";

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -2,6 +2,7 @@ import { TextClassContext } from '@/components/ui/text';
 import { cn } from '@/lib/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 import { Platform, Pressable } from 'react-native';
+import type { ComponentProps, RefAttributes } from 'react';
 
 const buttonVariants = cva(
   cn(
@@ -88,8 +89,8 @@ const buttonTextVariants = cva(
   }
 );
 
-type ButtonProps = React.ComponentProps<typeof Pressable> &
-  React.RefAttributes<typeof Pressable> &
+type ButtonProps = ComponentProps<typeof Pressable> &
+  RefAttributes<typeof Pressable> &
   VariantProps<typeof buttonVariants>;
 
 function Button({ className, variant, size, ...props }: ButtonProps) {

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,11 +1,12 @@
 import { cn } from '@/lib/utils';
 import { Platform, TextInput, type TextInputProps } from 'react-native';
+import type { RefAttributes } from 'react';
 
 function Input({
   className,
   placeholderClassName,
   ...props
-}: TextInputProps & React.RefAttributes<TextInput>) {
+}: TextInputProps & RefAttributes<TextInput>) {
   return (
     <TextInput
       className={cn(

--- a/components/ui/label.tsx
+++ b/components/ui/label.tsx
@@ -1,6 +1,7 @@
 import { cn } from '@/lib/utils';
 import * as LabelPrimitive from '@rn-primitives/label';
 import { Platform } from 'react-native';
+import type { RefAttributes } from 'react';
 
 function Label({
   className,
@@ -10,7 +11,7 @@ function Label({
   onPressOut,
   disabled,
   ...props
-}: LabelPrimitive.TextProps & React.RefAttributes<LabelPrimitive.TextRef>) {
+}: LabelPrimitive.TextProps & RefAttributes<LabelPrimitive.TextRef>) {
   return (
     <LabelPrimitive.Root
       className={cn(

--- a/components/ui/text.tsx
+++ b/components/ui/text.tsx
@@ -1,7 +1,12 @@
 import { cn } from '@/lib/utils';
 import * as Slot from '@rn-primitives/slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-import * as React from 'react';
+import {
+  createContext,
+  useContext,
+  type ComponentProps,
+  type RefAttributes,
+} from 'react';
 import { Platform, Text as RNText, type Role } from 'react-native';
 
 const textVariants = cva(
@@ -62,19 +67,19 @@ const ARIA_LEVEL: Partial<Record<TextVariant, string>> = {
   h4: '4',
 };
 
-const TextClassContext = React.createContext<string | undefined>(undefined);
+const TextClassContext = createContext<string | undefined>(undefined);
 
 function Text({
   className,
   asChild = false,
   variant = 'default',
   ...props
-}: React.ComponentProps<typeof RNText> &
+}: ComponentProps<typeof RNText> &
   TextVariantProps &
-  React.RefAttributes<RNText> & {
+  RefAttributes<RNText> & {
     asChild?: boolean;
   }) {
-  const textClass = React.useContext(TextClassContext);
+  const textClass = useContext(TextClassContext);
   const Component = asChild ? Slot.Text : RNText;
   return (
     <Component

--- a/global.d.ts
+++ b/global.d.ts
@@ -20,15 +20,15 @@ declare module '*.webp' {
   export default src;
 }
 declare module '*.svg' {
-  import * as React from 'react';
+  import type { FC } from 'react';
   import { SvgProps } from 'react-native-svg';
-  const content: React.FC<SvgProps>;
+  const content: FC<SvgProps>;
   export default content;
 }
 
 declare module '@react-native-async-storage/async-storage';
 declare module 'expo-symbols' {
-  import { ComponentType } from 'react';
+  import type { ComponentType } from 'react';
   import { ViewProps } from 'react-native';
 
   export type SymbolWeight =


### PR DESCRIPTION
## Summary
- drop deprecated default React imports in favor of named hooks and type imports
- update component types to use React's modern type utilities

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c1debba50c832ab495313eaccfc993